### PR TITLE
[1.8.0] Update Dependencies for new Smart Contracts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tacoinfra/harbinger-cli",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -106,9 +106,9 @@
       "integrity": "sha512-QuAva3K3YFDtQidi8xAfOQcb+aExJus3p0GhPNscOE+r152klBdiZUHLp818zEeQZT7PRSm83gEknmeUYjGU9A=="
     },
     "@tacoinfra/harbinger-lib": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@tacoinfra/harbinger-lib/-/harbinger-lib-1.4.0.tgz",
-      "integrity": "sha512-gbi3FgEpr5sxyX5Un3+uqXpnddHmpS3joTDko4QL8uAHoofylqrhcgoddhx08EBQA0NCKDajzo1FlftDWGzgbg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@tacoinfra/harbinger-lib/-/harbinger-lib-1.5.0.tgz",
+      "integrity": "sha512-piNJUnnvcqLMYbr2Tjl53gK7vUMC1pRYqRcy9ULIIv/zzItIPsSv+pWtibZTOIxXDCWCHbhX58qwuk1kEpZelQ==",
       "requires": {
         "@lapo/asn1js": "1.1.0",
         "@ledgerhq/hw-transport": "^5.15.0",
@@ -176,9 +176,9 @@
       "integrity": "sha512-Li91pVKcLvQJK3ZolwCPo85oxf2gKBCApgnesRxYg4OVYchLXcJB2eivX8S87vfQVv6ZRnyCO1lLDosZGJfpRg=="
     },
     "@types/node": {
-      "version": "14.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
-      "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA=="
+      "version": "14.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.4.tgz",
+      "integrity": "sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ=="
     },
     "@types/node-fetch": {
       "version": "2.5.7",
@@ -507,9 +507,9 @@
       }
     },
     "bl": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tacoinfra/harbinger-cli",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "This is client software for reading / writing from the BTC / USD oracle. The following contracts are hardcoded: - [Oracle contract to read from](https://you.better-call.dev/carthagenet/KT1XjYrm3AX5Ptw2ZKXTPYE5ZDFWprfdihKb/storage) - [Oracle contract to write to](https://you.better-call.dev/carthagenet/KT1DiFg6TxLgsCFAFmLgc9mBBUdE7TRnQzMG/storage)",
   "main": "build/src/cli.js",
   "files": [
@@ -27,7 +27,7 @@
     "conseiljs": "5.0.4",
     "loglevel": "^1.6.8",
     "node-fetch": "^2.6.0",
-    "@tacoinfra/harbinger-lib": "1.4.0",
+    "@tacoinfra/harbinger-lib": "^1.5.0",
     "ts-node": "^8.8.1",
     "typescript": "^3.8.3"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,7 @@ import {
 } from '@tacoinfra/harbinger-lib'
 import * as commander from 'commander'
 
-const version = '1.7.0'
+const version = '1.8.0'
 
 const defaultTestnetNode = 'https://rpctest.tzbeta.net'
 const defaultMainnetNode = 'https://rpc.tzbeta.net'


### PR DESCRIPTION
Pull in `harbinger-lib`@1.5.0. This pulls in two smart contract changes in the normalizer, see:
https://github.com/tacoinfra/harbinger-contracts/pull/22
https://github.com/tacoinfra/harbinger-contracts/pull/23

Also run `npm audit fix` to update dependencies. 

I'll run `npm publish` offline and annotate this PR.